### PR TITLE
Fix typo in private-endpoint-how-to.md

### DIFF
--- a/azure-video-indexer/private-endpoint-how-to.md
+++ b/azure-video-indexer/private-endpoint-how-to.md
@@ -18,7 +18,7 @@ This article shows you how to use private endpoints with Azure AI Video Indexer 
 
 ## Prerequisites
 
-- A [viirtual network and a subnet](/azure/virtual-network/quick-create-portal).
+- A [virtual network and a subnet](/azure/virtual-network/quick-create-portal).
 
 ## Enable the private endpoint on the Azure AI Video Indexer account
 


### PR DESCRIPTION
There's a small typo on [this page](https://learn.microsoft.com/en-us/azure/azure-video-indexer/private-endpoint-how-to). This PR fixes it.