### PR TITLE
Update language-support.md

### DIFF
--- a/azure-video-indexer/language-support.md
+++ b/azure-video-indexer/language-support.md
@@ -69,7 +69,6 @@ This section explains the Video Indexer language options and has a table of the 
 | Catalan | ca-ES | ✔ | ✔ |✔ | ✔ | ✔ | ✔ |  |
 | Chinese (Cantonese Traditional) | zh-HK | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |  |
 | Chinese (Simplified) | zh-Hans | ✔ | ✔ | ✔ |  |  | ✔ | ✔ |
-| Chinese (Simplified) | zh-CK | ✔ | ✔ | ✔ |  |  | ✔ | ✔ |
 | Chinese (Traditional) | zh-Hant |  | ✔ |  |  |  | ✔ |  |
 | Croatian | hr-HR | ✔ | ✔ | ✔ |  | ✔ | ✔ |  |
 | Czech | cs-CZ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |


### PR DESCRIPTION
Simplified Chinese is not represented by zh-CK. In fact, zh-CK is not a recognized variant of Chinese. Also, according to https://api-portal.videoindexer.ai/api-details#api=Operations&operation=Get-Video-Index, only the following are supported: Chinese (Simplified): zh-Hans, Chinese (Traditional): zh-Hant, Chinese (Cantonese, Traditional): zh-HK.